### PR TITLE
feat: exposing exclude prop in construct

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,6 +157,7 @@ const tokenInjectableDockerBuilderProps: TokenInjectableDockerBuilderProps = { .
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.buildArgs">buildArgs</a></code> | <code>{[ key: string ]: string}</code> | Build arguments to pass to the Docker build process. |
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.completenessQueryInterval">completenessQueryInterval</a></code> | <code>aws-cdk-lib.Duration</code> | The query interval for checking if the CodeBuild project has completed. |
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.dockerLoginSecretArn">dockerLoginSecretArn</a></code> | <code>string</code> | The ARN of the AWS Secrets Manager secret containing Docker login credentials. |
+| <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.exclude">exclude</a></code> | <code>string[]</code> | A list of file paths in the Docker directory to exclude from build. |
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.installCommands">installCommands</a></code> | <code>string[]</code> | Custom commands to run during the install phase of CodeBuild. |
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.kmsEncryption">kmsEncryption</a></code> | <code>boolean</code> | Whether to enable KMS encryption for the ECR repository. |
 | <code><a href="#token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.preBuildCommands">preBuildCommands</a></code> | <code>string[]</code> | Custom commands to run during the pre_build phase of CodeBuild. |
@@ -246,6 +247,21 @@ If not provided (or not needed), the construct will skip Docker Hub login.
 'arn:aws:secretsmanager:us-east-1:123456789012:secret:DockerLoginSecret'
 ```
 
+
+##### `exclude`<sup>Optional</sup> <a name="exclude" id="token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.exclude"></a>
+
+```typescript
+public readonly exclude: string[];
+```
+
+- *Type:* string[]
+- *Default:* No file path exclusions
+
+A list of file paths in the Docker directory to exclude from build.
+
+Will use paths in .dockerignore file if present.
+
+---
 
 ##### `installCommands`<sup>Optional</sup> <a name="installCommands" id="token-injectable-docker-builder.TokenInjectableDockerBuilderProps.property.installCommands"></a>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
+import * as fs from 'fs';
+
 import { CustomResource, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { Project, Source, LinuxBuildImage, BuildSpec } from 'aws-cdk-lib/aws-codebuild';
 import { IVpc, ISecurityGroup, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
@@ -120,6 +122,14 @@ export interface TokenInjectableDockerBuilderProps {
    * @default - Duration.seconds(30)
    */
   readonly completenessQueryInterval?: Duration;
+
+  /**
+   * A list of file paths in the Docker directory to exclude from build.
+   * Will use paths in .dockerignore file if present.
+   *
+   * @default - No file path exclusions
+   */
+  readonly exclude?: string[];
 }
 
 /**
@@ -166,6 +176,7 @@ export class TokenInjectableDockerBuilder extends Construct {
       preBuildCommands,
       kmsEncryption = false,
       completenessQueryInterval,
+      exclude
     } = props;
 
     // Generate an ephemeral tag for CodeBuild
@@ -194,9 +205,22 @@ export class TokenInjectableDockerBuilder extends Construct {
       imageScanOnPush: true,
     });
 
+    let effectiveExclude = exclude;
+    if (!effectiveExclude) {
+      const dockerignorePath = path.join(sourcePath, '.dockerignore');
+      if (fs.existsSync(dockerignorePath)) {
+        const fileContent = fs.readFileSync(dockerignorePath, 'utf8');
+        effectiveExclude = fileContent
+          .split('\n')
+          .map((line: string) => line.trim())
+          .filter((line: string) => line.length > 0 && !line.startsWith('#'));
+      }
+    }
+
     // Wrap the source folder as an S3 asset for CodeBuild to use
     const sourceAsset = new Asset(this, 'SourceAsset', {
       path: sourcePath,
+      exclude: effectiveExclude
     });
 
     // Create an S3 bucket to store the CodeBuild artifacts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 
 import { CustomResource, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { Project, Source, LinuxBuildImage, BuildSpec } from 'aws-cdk-lib/aws-codebuild';
@@ -176,7 +176,7 @@ export class TokenInjectableDockerBuilder extends Construct {
       preBuildCommands,
       kmsEncryption = false,
       completenessQueryInterval,
-      exclude
+      exclude,
     } = props;
 
     // Generate an ephemeral tag for CodeBuild
@@ -220,7 +220,7 @@ export class TokenInjectableDockerBuilder extends Construct {
     // Wrap the source folder as an S3 asset for CodeBuild to use
     const sourceAsset = new Asset(this, 'SourceAsset', {
       path: sourcePath,
-      exclude: effectiveExclude
+      exclude: effectiveExclude,
     });
 
     // Create an S3 bucket to store the CodeBuild artifacts


### PR DESCRIPTION
Fixes #11

Surface the `exclude` prop in the construct to allow excluding files from the Docker build.

* Add `exclude` prop to `TokenInjectableDockerBuilderProps` interface in `src/index.ts`.
* Include `exclude` prop when creating the `Asset` instance in `src/index.ts`.
* Read `.dockerignore` file if `exclude` prop is not provided and use its contents to set the `exclude` prop.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlexTech314/TokenInjectableDockerBuilder/pull/12?shareId=f1c665f2-b080-414d-9b05-e015d55e57e6).