### PR TITLE
fix: never exclude Dockerfile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,8 @@ export class TokenInjectableDockerBuilder extends Construct {
       }
     }
 
+    effectiveExclude = effectiveExclude.filter(path => path !== "Dockerfile");
+
     // Wrap the source folder as an S3 asset for CodeBuild to use
     const sourceAsset = new Asset(this, 'SourceAsset', {
       path: sourcePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,8 +205,8 @@ export class TokenInjectableDockerBuilder extends Construct {
       imageScanOnPush: true,
     });
 
-    let effectiveExclude = exclude;
-    if (!effectiveExclude) {
+    let effectiveExclude = exclude || [];
+    if (effectiveExclude.length === 0) {
       const dockerignorePath = path.join(sourcePath, '.dockerignore');
       if (fs.existsSync(dockerignorePath)) {
         const fileContent = fs.readFileSync(dockerignorePath, 'utf8');


### PR DESCRIPTION
I just noticed builds started failing - I have `Dockerfile` in `.dockerignore`. 

It makes sense for the purpose of the `.dockerignore` file but it broke builds here. There would be no reason to ever exclude it for this construct so I added a final pass to remove it from the exclusion list if present.

Fixes #18 